### PR TITLE
Add context field to News Domain class and update asDomainModel functions

### DIFF
--- a/app/src/main/java/com/android/example/toynewsapplication/data/domain/News.kt
+++ b/app/src/main/java/com/android/example/toynewsapplication/data/domain/News.kt
@@ -1,6 +1,7 @@
 package com.android.example.toynewsapplication.data.domain
 
 import android.os.Parcelable
+import com.android.example.toynewsapplication.data.local.model.GptEntity
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -11,5 +12,13 @@ data class News(
     val url: String,
     val urlToImage: String,
     val publishedAt: String,
-    val content: String?
+    val content: String?,
+    val context: String?
 ): Parcelable
+
+fun String.asDatabaseModel(newsId: Int): GptEntity {
+    return GptEntity(
+        newsId = newsId,
+        context = this
+    )
+}

--- a/app/src/main/java/com/android/example/toynewsapplication/data/local/model/NewsEntity.kt
+++ b/app/src/main/java/com/android/example/toynewsapplication/data/local/model/NewsEntity.kt
@@ -26,7 +26,8 @@ fun List<NewsEntity>.asDomainModel(): List<News> {
             url = it.url,
             urlToImage = it.imageUrl,
             publishedAt = it.publishedAt,
-            content = it.content
+            content = it.content,
+            context = ""
         )
     }
 }

--- a/app/src/main/java/com/android/example/toynewsapplication/data/remote/model/Article.kt
+++ b/app/src/main/java/com/android/example/toynewsapplication/data/remote/model/Article.kt
@@ -28,7 +28,8 @@ fun List<Article>.asDomainModel(): List<News> {
             url = it.url,
             urlToImage = it.urlToImage ?: "",
             publishedAt = it.publishedAt,
-            content = it.content
+            content = it.content,
+            context = ""
         )
     }
 }


### PR DESCRIPTION
This pull request adds a nullable context field to the News Domain class and updates the asDomainModel functions accordingly.

The context field is necessary as OpenAI generates it and inserts it into the News class. As a result, the context field has been added to the asDomainModel functions, which transform Entity class and response class instances into domain class instances.

Please review these changes and consider merging this pull request if you agree with the updates.