### PR TITLE
Add transformation functions in Gpt.kt

### DIFF
--- a/app/src/main/java/com/android/example/toynewsapplication/data/remote/model/Gpt.kt
+++ b/app/src/main/java/com/android/example/toynewsapplication/data/remote/model/Gpt.kt
@@ -1,5 +1,7 @@
 package com.android.example.toynewsapplication.data.remote.model
 
+import com.android.example.toynewsapplication.data.domain.News
+
 data class GptResponseBody(
     val id: String,
     val gpt_object: String,
@@ -23,9 +25,27 @@ data class GptLogprobs(
 )
 
 data class GptRequestBody(
-    val model: String,
-    val propmpt: String,
+    val model: String = "gpt-3.5-turbo",
+    val prompt: String,
     val max_tokens: Int = 1024,
     val n: Int = 1,
     val temperature: Double = 0.5
 )
+
+fun GptResponseBody.extractText(): String {
+    return choices[0].text
+}
+
+fun News.createGptRequestBody(): GptRequestBody {
+    return GptRequestBody(
+        prompt = "" +
+                "This is a news article about ${title}. $description $content" +
+                "Return informational context which is necessary to understand the article" +
+                "based on the scientific research on this topic." +
+                "Response structure:" +
+                "1. Summary of the context" +
+                "2. Main points of the context" +
+                "3. Further study relevant to the context" +
+                "Please write an answer in Japanese"
+    )
+}


### PR DESCRIPTION
This pull request adds two extension functions to Gpt.kt for processing OpenAI API responses and creating prompts:

GptResponseBody.extractText - Extracts the context string from the API response.
News.createGptRequestBody - Generates a prompt using the news title, description, and content.
Please review the changes and consider merging this pull request if you agree with the additions.