### PR TITLE
Add foreign keys for one-to-one relation between gpt and news tables

### DIFF
--- a/app/src/main/java/com/android/example/toynewsapplication/data/local/model/GptEntity.kt
+++ b/app/src/main/java/com/android/example/toynewsapplication/data/local/model/GptEntity.kt
@@ -1,3 +1,23 @@
 package com.android.example.toynewsapplication.data.local.model
 
-data class GptEntity()
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "gpt",
+    foreignKeys = [
+        ForeignKey(
+            entity = NewsEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["newsId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class GptEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val newsId: Int,
+    val context: String,
+)


### PR DESCRIPTION
This pull request adds foreign key parameters to establish a one-to-one relationship between the gpt and news tables, connecting them via the newsId foreign key.

By creating this relationship, we ensure data integrity and consistency between the two tables, simplifying data management in the database.

Please review these changes and consider merging this pull request if you agree with the updates.